### PR TITLE
Make the library isomorphic to make it usable in SSR environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reclaim-ai/react-intercom-hook",
-  "version": "2.0.3",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/useIntercom.node.spec.tsx
+++ b/src/useIntercom.node.spec.tsx
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable @typescript-eslint/camelcase */
+import { renderHook } from "@testing-library/react-hooks";
+import { useIntercom } from "./useIntercom";
+
+test("should render silently in Node environment", () => {
+  const { result } = renderHook(() => useIntercom({ app_id: "abc" }));
+  expect(result.current).toBeDefined();
+});


### PR DESCRIPTION
Hi there!

I wanted to use the library in a Next.js (SSR) project. However, the server was complaining because `window` is not defined in a pure Node environment.

I took inspiration from [react-ga](https://github.com/react-ga/react-ga/blob/f3f19634f3ba28687c6b66067eb884cd0be21f0f/src/core.js) and [stripe-js](https://github.com/stripe/stripe-js/blob/master/src/shared.ts) to make the code "isomorphic", i.e. working both in backend and frontend environments. Basically, we check if `window` is defined before executing the logic of each methods. So, on the server side, it does nothing.

I've added a Jest unit test with the `node` environment to check we can call the hook without raising an error.

I'm aware that this may not be very elegant, but I'm open to suggestions on this matter 🙂

Cheers!